### PR TITLE
Run on macOS, Linux, and the BSDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,28 @@ No installation required. Just run `ASAdventurer.exe` and open your browser.
 
 ## Quick Start
 
+**Windows**
+
 1. **Double-click** `ASAdventurer.exe` (or use `Start AS Adventurer.bat`)
 2. Your browser will open to `http://localhost:3001`
 3. Follow the 4-step pipeline below
+
+**macOS**
+
+1. **Double-click** `Start ASAdventurer.command`
+2. Your browser will open to `http://localhost:3001`
+
+**Linux and the BSDs**
+
+```sh
+./bin/start          # or simply: npm start
+```
+
+The launcher checks for Node.js and reports the install command for your
+platform if it is missing. It does not install anything itself.
+
+Set `AS_NO_OPEN=1` to stop the server opening a browser, which is useful
+headless and on systems without `xdg-open`.
 
 ---
 
@@ -136,10 +155,24 @@ The exported WebM files also work with any OBS browser source, PNGtuber app, or 
 
 ## System Requirements
 
-- **OS:** Windows 10/11 (64-bit)
+- **OS:** Windows 10/11, macOS, Linux, or FreeBSD/OpenBSD/NetBSD (64-bit)
+- **Node.js:** 18 or newer, required on every platform except when running a
+  prebuilt binary on Windows or macOS
 - **Browser:** Chrome, Edge, or Firefox (opens automatically)
 - **Internet:** Required only for AI generation steps (Steps 1-2). Steps 3-4 work fully offline.
 - **Disk Space:** ~40 MB for the application
+
+### Building a standalone binary
+
+`node build-exe.js` produces a self-contained binary for the platform it is
+run on, into `dist/ASAdventurer/`. Windows, macOS, and Linux are supported.
+The BSDs are not, because `pkg` publishes no base binary for them; run the
+application with `npm start` there instead.
+
+On macOS the build applies an ad-hoc code signature so the result runs on the
+machine that produced it. That is not notarization. Distributing the binary to
+another Mac requires an Apple Developer ID and a notarization step, or the
+recipient clearing the quarantine attribute by hand.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 AS Adventurer Creator is a standalone desktop tool that lets you create animated VTuber / PNGtuber assets from scratch. It walks you through a simple 4-step pipeline — from a static sprite all the way to a transparent, looping animated model ready for streaming.
 
-No installation required. Just run `ASAdventurer.exe` and open your browser.
+No installation required for the prebuilt binary. Run it and open your browser. From source, Node.js 18 or newer is the only prerequisite.
 
 ---
 
@@ -178,13 +178,16 @@ recipient clearing the quarantine attribute by hand.
 
 ## File Structure
 
+The built distribution, where the binary and launcher names follow the
+platform they were built on:
+
 ```
 ASAdventurer/
-├── ASAdventurer.exe          ← Main application (double-click to run)
-├── Start AS Adventurer.bat   ← Launcher with console output
-├── README.md                 ← This file
-├── icon.ico                  ← Application icon
-└── public/                   ← UI files (do not modify)
+├── ASAdventurer[.exe]                ← Main application (double-click to run)
+├── Start AS Adventurer.[bat|command|sh]  ← Launcher with console output
+├── README.md                         ← This file
+├── icon.ico                          ← Application icon (Windows builds only)
+└── public/                           ← UI files (do not modify)
     ├── index.html
     ├── style.css
     ├── sprite-prep.js

--- a/Start ASAdventurer.command
+++ b/Start ASAdventurer.command
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Finder shim. Double-clicking a .command file opens it in Terminal, which is
 # the only reason this file exists separately from bin/start.
-exec "$(CDPATH= cd -- "$(dirname "$0")" && pwd)/bin/start" "$@"
+exec "$(CDPATH='' cd -- "$(dirname "$0")" && pwd)/bin/start" "$@"

--- a/Start ASAdventurer.command
+++ b/Start ASAdventurer.command
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Finder shim. Double-clicking a .command file opens it in Terminal, which is
+# the only reason this file exists separately from bin/start.
+exec "$(CDPATH= cd -- "$(dirname "$0")" && pwd)/bin/start" "$@"

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# AS Adventurer launcher for macOS, Linux, and the BSDs.
+#
+# POSIX sh only. /bin/sh is not bash on FreeBSD, OpenBSD, or NetBSD, so
+# bashisms here would fail there while passing everywhere else.
+#
+# This script does not install anything. On a multi-user or packaged system
+# that is the operator's decision, not the launcher's, so a missing
+# dependency is reported and the script exits non-zero.
+
+set -eu
+
+# Finder starts .command files in $HOME, so the working directory cannot be
+# trusted. Resolve the repository root from this script's own path instead.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR/.."
+
+if ! command -v node >/dev/null 2>&1; then
+    printf 'AS Adventurer requires Node.js, which is not on PATH.\n\n' >&2
+    case "$(uname -s)" in
+        Darwin)
+            printf '  brew install node\n' >&2
+            printf '  sudo port install nodejs22    MacPorts\n' >&2 ;;
+        Linux)
+            printf '  apt install nodejs npm    Debian and Ubuntu\n' >&2
+            printf '  dnf install nodejs        Fedora and RHEL\n' >&2
+            printf '  pacman -S nodejs npm      Arch\n' >&2 ;;
+        FreeBSD)
+            printf '  pkg install node npm\n' >&2 ;;
+        OpenBSD)
+            printf '  pkg_add node\n' >&2 ;;
+        NetBSD)
+            printf '  pkgin install nodejs\n' >&2 ;;
+        *)
+            printf '  See https://nodejs.org/\n' >&2 ;;
+    esac
+    printf '\n' >&2
+    exit 1
+fi
+
+# Node is available by this point, so let it compare its own version rather
+# than parsing a version string in the shell.
+NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+    printf 'AS Adventurer requires Node.js 18 or newer. Found %s.\n' "$(node --version)" >&2
+    exit 1
+fi
+
+if [ ! -d node_modules ]; then
+    printf '  Installing dependencies...\n'
+    npm install
+fi
+
+# exec so that the server replaces this shell and receives Ctrl+C directly.
+exec node server.js

--- a/bin/start
+++ b/bin/start
@@ -13,7 +13,7 @@ set -eu
 
 # Finder starts .command files in $HOME, so the working directory cannot be
 # trusted. Resolve the repository root from this script's own path instead.
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
 cd "$SCRIPT_DIR/.."
 
 if ! command -v node >/dev/null 2>&1; then

--- a/bin/start
+++ b/bin/start
@@ -40,14 +40,30 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 # Node is available by this point, so let it compare its own version rather
-# than parsing a version string in the shell.
-NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]')
+# than parsing a version string in the shell. A failure here means node is on
+# PATH but not working, which set -e would otherwise report as silence.
+NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null) || NODE_MAJOR=''
+case "$NODE_MAJOR" in
+    ''|*[!0-9]*)
+        printf 'Found node at %s but could not read its version.\n' "$(command -v node)" >&2
+        printf 'The installation appears to be broken.\n' >&2
+        exit 1 ;;
+esac
+
 if [ "$NODE_MAJOR" -lt 18 ]; then
     printf 'AS Adventurer requires Node.js 18 or newer. Found %s.\n' "$(node --version)" >&2
     exit 1
 fi
 
 if [ ! -d node_modules ]; then
+    # Several distributions ship nodejs and npm as separate packages, so the
+    # presence of node says nothing about npm.
+    if ! command -v npm >/dev/null 2>&1; then
+        printf 'Dependencies are not installed and npm is not on PATH.\n' >&2
+        printf 'npm is packaged separately from nodejs on some systems.\n\n' >&2
+        printf 'Install npm, then run:  npm install\n\n' >&2
+        exit 1
+    fi
     printf '  Installing dependencies...\n'
     npm install
 fi

--- a/build-exe.js
+++ b/build-exe.js
@@ -99,7 +99,7 @@ if (fs.existsSync(DIST)) {
 }
 fs.mkdirSync(DIST, { recursive: true });
 
-// 3. Compile EXE with pkg
+// 3. Compile the binary with pkg
 log(`Compiling server.js → ${HOST.binary} (${HOST.target}) ...`);
 const ICON = path.join(ROOT, 'icon.ico');
 const BIN = path.join(DIST, HOST.binary);

--- a/build-exe.js
+++ b/build-exe.js
@@ -9,7 +9,7 @@
  * Output goes to: dist/ASAdventurer/
  *   ├── ASAdventurer[.exe]
  *   ├── public/          (UI files: sprite-prep, video-prep, model-exporter)
- *   └── Start AS Adventurer.[bat|command]
+ *   └── Start AS Adventurer.[bat|command|sh]
  *
  * pkg ships prebuilt base binaries for Windows, macOS, and Linux only. There
  * is no FreeBSD, OpenBSD, or NetBSD target, so on those systems this script
@@ -30,7 +30,7 @@ const ARCH = { x64: 'x64', arm64: 'arm64' }[process.arch];
 const HOST = !ARCH ? null : {
   win32:  { target: `node18-win-${ARCH}`,   binary: 'ASAdventurer.exe', launcher: 'bat' },
   darwin: { target: `node18-macos-${ARCH}`, binary: 'ASAdventurer',     launcher: 'command' },
-  linux:  { target: `node18-linux-${ARCH}`, binary: 'ASAdventurer',     launcher: 'command' }
+  linux:  { target: `node18-linux-${ARCH}`, binary: 'ASAdventurer',     launcher: 'sh' }
 }[process.platform];
 
 if (!HOST) {
@@ -165,11 +165,11 @@ pause
 } else {
   // Named .command so Finder will run it on a double-click. Harmless on
   // Linux, where it is an ordinary POSIX script.
-  const launcher = path.join(DIST, 'Start AS Adventurer.command');
+  const launcher = path.join(DIST, `Start AS Adventurer.${HOST.launcher}`);
   fs.writeFileSync(launcher,
 `#!/bin/sh
 set -eu
-cd "$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+cd "$(CDPATH='' cd -- "$(dirname "$0")" && pwd)"
 printf '\n  AS Adventurer\n  Open your browser to: http://localhost:3001\n\n'
 exec ./${HOST.binary}
 `);

--- a/build-exe.js
+++ b/build-exe.js
@@ -11,9 +11,10 @@
  *   ├── public/          (UI files: sprite-prep, video-prep, model-exporter)
  *   └── Start AS Adventurer.[bat|command|sh]
  *
- * pkg ships prebuilt base binaries for Windows, macOS, and Linux only. There
- * is no FreeBSD, OpenBSD, or NetBSD target, so on those systems this script
- * refuses rather than producing something broken. `npm start` works there.
+ * pkg ships prebuilt base binaries for Windows, macOS, and Linux only. It
+ * recognises a freebsd target name, but no binary is published for it and
+ * pkg will not cross-build one, so on the BSDs this script refuses rather
+ * than producing something broken. `npm start` works there regardless.
  *
  * pkg itself is archived upstream, which is why the targets stop at Node 18.
  * Node's own single executable applications feature is the eventual

--- a/build-exe.js
+++ b/build-exe.js
@@ -1,19 +1,47 @@
 #!/usr/bin/env node
 /**
- * Build script: Compiles AS Adventurer into a standalone EXE.
- * 
+ * Build script: compiles AS Adventurer into a standalone binary for the
+ * platform it is run on.
+ *
  * Usage: node build-exe.js
- * Or just double-click: build-exe.bat
- * 
+ * Or on Windows, double-click: build-exe.bat
+ *
  * Output goes to: dist/ASAdventurer/
- *   ├── ASAdventurer.exe
+ *   ├── ASAdventurer[.exe]
  *   ├── public/          (UI files: sprite-prep, video-prep, model-exporter)
- *   └── Start AS Adventurer.bat
+ *   └── Start AS Adventurer.[bat|command]
+ *
+ * pkg ships prebuilt base binaries for Windows, macOS, and Linux only. There
+ * is no FreeBSD, OpenBSD, or NetBSD target, so on those systems this script
+ * refuses rather than producing something broken. `npm start` works there.
+ *
+ * pkg itself is archived upstream, which is why the targets stop at Node 18.
+ * Node's own single executable applications feature is the eventual
+ * replacement, and it will need the same macOS signing step handled below.
  */
 
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+
+// ── Host platform ────────────────────────────────
+// pkg target triples, output name, and launcher flavour all follow from this.
+const ARCH = { x64: 'x64', arm64: 'arm64' }[process.arch];
+const HOST = !ARCH ? null : {
+  win32:  { target: `node18-win-${ARCH}`,   binary: 'ASAdventurer.exe', launcher: 'bat' },
+  darwin: { target: `node18-macos-${ARCH}`, binary: 'ASAdventurer',     launcher: 'command' },
+  linux:  { target: `node18-linux-${ARCH}`, binary: 'ASAdventurer',     launcher: 'command' }
+}[process.platform];
+
+if (!HOST) {
+  console.error();
+  console.error(`  pkg has no prebuilt target for ${process.platform}/${process.arch}.`);
+  console.error('  Run the application directly instead:');
+  console.error();
+  console.error('      npm start');
+  console.error();
+  process.exit(1);
+}
 
 const ROOT = __dirname;
 const DIST = path.join(ROOT, 'dist', 'ASAdventurer');
@@ -22,6 +50,17 @@ const PUBLIC_DEST = path.join(DIST, 'public');
 
 // ── Helpers ──────────────────────────────────────
 function log(msg) { console.log(`  ${msg}`); }
+
+// Availability probe for POSIX archivers. Not used on Windows, which has
+// PowerShell's Compress-Archive unconditionally.
+function hasCommand(cmd) {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: 'pipe', shell: '/bin/sh' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 function copyDirSync(src, dest, exclude = []) {
   fs.mkdirSync(dest, { recursive: true });
@@ -61,15 +100,17 @@ if (fs.existsSync(DIST)) {
 fs.mkdirSync(DIST, { recursive: true });
 
 // 3. Compile EXE with pkg
-log('Compiling server.js → ASAdventurer.exe ...');
+log(`Compiling server.js → ${HOST.binary} (${HOST.target}) ...`);
 const ICON = path.join(ROOT, 'icon.ico');
+const BIN = path.join(DIST, HOST.binary);
 const pkgCmd = [
   'npx --yes pkg',
   `"${path.join(ROOT, 'server.js')}"`,
-  '--targets node18-win-x64',
-  '--output', `"${path.join(DIST, 'ASAdventurer.exe')}"`,
+  `--targets ${HOST.target}`,
+  '--output', `"${BIN}"`,
   '--compress GZip',
-  fs.existsSync(ICON) ? `--icon "${ICON}"` : ''
+  // --icon writes Windows PE resources and is rejected on other targets.
+  (process.platform === 'win32' && fs.existsSync(ICON)) ? `--icon "${ICON}"` : ''
 ].filter(Boolean).join(' ');
 
 try {
@@ -79,6 +120,25 @@ try {
   process.exit(1);
 }
 
+// 3b. Executable bit, and a signature on macOS
+if (process.platform !== 'win32') {
+  fs.chmodSync(BIN, 0o755);
+}
+
+// Apple Silicon refuses to execute an unsigned binary outright. An ad-hoc
+// signature costs nothing and makes the build runnable on this machine.
+// This is NOT notarization: another Mac will still quarantine the download
+// unless the user clears the attribute, or the binary is signed with a
+// Developer ID and notarized through Apple.
+if (process.platform === 'darwin') {
+  try {
+    execSync(`codesign --force --sign - "${BIN}"`, { stdio: 'pipe' });
+    log('Applied an ad-hoc signature (runs here; not notarized for others).');
+  } catch (e) {
+    log('⚠️  codesign failed — the binary may be blocked on Apple Silicon.');
+  }
+}
+
 // 4. Copy public/ folder
 log('Copying public/ files...');
 copyDirSync(PUBLIC_SRC, PUBLIC_DEST, []);
@@ -86,8 +146,9 @@ copyDirSync(PUBLIC_SRC, PUBLIC_DEST, []);
 
 
 
-// 6. Create a launcher bat
-fs.writeFileSync(path.join(DIST, 'Start AS Adventurer.bat'),
+// 6. Create a launcher for the host platform
+if (HOST.launcher === 'bat') {
+  fs.writeFileSync(path.join(DIST, 'Start AS Adventurer.bat'),
 `@echo off
 echo.
 echo  ============================================
@@ -101,9 +162,22 @@ start http://localhost:3001
 ASAdventurer.exe
 pause
 `);
+} else {
+  // Named .command so Finder will run it on a double-click. Harmless on
+  // Linux, where it is an ordinary POSIX script.
+  const launcher = path.join(DIST, 'Start AS Adventurer.command');
+  fs.writeFileSync(launcher,
+`#!/bin/sh
+set -eu
+cd "$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+printf '\n  AS Adventurer\n  Open your browser to: http://localhost:3001\n\n'
+exec ./${HOST.binary}
+`);
+  fs.chmodSync(launcher, 0o755);
+}
 
-// 7. Copy icon alongside exe for reference
-if (fs.existsSync(ICON)) {
+// 7. Copy icon alongside the binary for reference (Windows resource format)
+if (process.platform === 'win32' && fs.existsSync(ICON)) {
   fs.copyFileSync(ICON, path.join(DIST, 'icon.ico'));
 }
 
@@ -119,7 +193,17 @@ const ZIP_PATH = path.join(ROOT, 'dist', 'ASAdventurer.zip');
 log('Creating distributable ZIP...');
 try {
   if (fs.existsSync(ZIP_PATH)) fs.unlinkSync(ZIP_PATH);
-  execSync(`powershell -NoProfile -Command "Compress-Archive -Path '${DIST}' -DestinationPath '${ZIP_PATH}' -Force"`, { stdio: 'pipe' });
+  if (process.platform === 'win32') {
+    execSync(`powershell -NoProfile -Command "Compress-Archive -Path '${DIST}' -DestinationPath '${ZIP_PATH}' -Force"`, { stdio: 'pipe' });
+  } else if (process.platform === 'darwin' && hasCommand('ditto')) {
+    // ditto preserves the executable bit and the ad-hoc signature, both of
+    // which a plain zip round-trip can lose.
+    execSync(`ditto -c -k --sequesterRsrc --keepParent "${DIST}" "${ZIP_PATH}"`, { stdio: 'pipe' });
+  } else if (hasCommand('zip')) {
+    execSync(`zip -r -q -y "${ZIP_PATH}" "ASAdventurer"`, { stdio: 'pipe', cwd: path.join(ROOT, 'dist') });
+  } else {
+    throw new Error('no archiver found; install zip or archive dist/ASAdventurer by hand');
+  }
   const zipSize = (fs.statSync(ZIP_PATH).size / (1024 * 1024)).toFixed(1);
   log(`Created ASAdventurer.zip (${zipSize} MB)`);
 } catch (e) {
@@ -135,8 +219,8 @@ log(`Output: ${DIST}`);
 log(`   ZIP: ${ZIP_PATH}`);
 log('');
 log('Contents:');
-log('  ASAdventurer.exe             — Double-click to run');
-log('  Start AS Adventurer.bat      — Launcher (opens browser automatically)');
+log(`  ${HOST.binary.padEnd(28)} — Double-click to run`);
+log(`  ${('Start AS Adventurer.' + HOST.launcher).padEnd(28)} — Launcher (opens browser automatically)`);
 log('  README.md                    — Documentation');
 log('  public/                      — UI files');
 console.log();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "⚔️ AS Adventurer — VTuber Creation Pipeline by Angel's Sword Studios",
   "main": "server.js",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "start": "node server.js"
   },

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const express = require('express');
 const fetch = require('node-fetch');
 const FormData = require('form-data');
 const path = require('path');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -271,9 +271,15 @@ app.listen(PORT, () => {
     // is frequently not installed.
     if (process.env.AS_NO_OPEN !== '1') {
         const url = `http://localhost:${PORT}`;
-        const opener = process.platform === 'win32' ? 'start' :
-                       process.platform === 'darwin' ? 'open' : 'xdg-open';
+        // execFile rather than exec, so there is no shell and PORT cannot be
+        // interpolated into a command line. On Windows `start` is a cmd
+        // builtin, and its first quoted argument is the window title.
+        const [opener, args] = process.platform === 'win32'
+            ? ['cmd', ['/c', 'start', '', url]]
+            : process.platform === 'darwin'
+                ? ['open', [url]]
+                : ['xdg-open', [url]];
         // Failure is not fatal. The URL is printed above either way.
-        exec(`${opener} ${url}`, () => {});
+        execFile(opener, args, () => {});
     }
 });

--- a/server.js
+++ b/server.js
@@ -266,9 +266,14 @@ app.listen(PORT, () => {
     console.log('  Press Ctrl+C to stop');
     console.log('');
 
-    // Auto-open browser
-    const url = `http://localhost:${PORT}`;
-    const start = process.platform === 'win32' ? 'start' :
-                  process.platform === 'darwin' ? 'open' : 'xdg-open';
-    exec(`${start} ${url}`);
+    // Auto-open browser. Set AS_NO_OPEN=1 to suppress it, which matters for
+    // headless CI and for the BSDs, where xdg-open comes from xdg-utils and
+    // is frequently not installed.
+    if (process.env.AS_NO_OPEN !== '1') {
+        const url = `http://localhost:${PORT}`;
+        const opener = process.platform === 'win32' ? 'start' :
+                       process.platform === 'darwin' ? 'open' : 'xdg-open';
+        // Failure is not fatal. The URL is printed above either way.
+        exec(`${opener} ${url}`, () => {});
+    }
 });


### PR DESCRIPTION
Makes the tool run on macOS, Linux, and the BSDs.

The runtime was already portable. `server.js` branches on `process.platform` and the `process.pkg` path logic is platform-neutral, so the application has always run on Unix with `npm start`. Everything Windows-specific lived in the launch and packaging layer, and that is the whole of what changes here.

No proxy route is touched. The provider paths are byte-identical to `main`.

## What changed

**`bin/start`** — POSIX `sh` launcher. Resolves the repository root from its own path, checks for Node 18 or newer, installs dependencies when `node_modules` is absent, and `exec`s the server so Ctrl+C reaches it directly.

Strict POSIX rather than bash, because `/bin/sh` on FreeBSD, OpenBSD, and NetBSD is not bash. A bashism would pass on most Linux distributions and fail there. `command -v` rather than `which` for the same reason.

It reports how to install Node and exits non-zero. It does not install anything, because on a packaged system that is the operator's decision.

**`Start ASAdventurer.command`** — three-line Finder shim. Finder only double-click-executes `.command` files, and it starts them in `$HOME` rather than the script's directory, which is why the root resolution in `bin/start` is not optional.

**`build-exe.js`** — host-aware. The pkg target triple, output name, `--icon` flag, generated launcher, and archiver all follow from `process.platform` and `process.arch`.

- `--icon` writes Windows PE resources and is rejected elsewhere, so it is now Windows-only.
- Archiver is PowerShell `Compress-Archive` on Windows, `ditto` on macOS because it preserves the executable bit and the signature, `zip` otherwise.
- pkg publishes no BSD base binary, so the script refuses there and points at `npm start` rather than emitting something broken.
- On macOS it applies an ad-hoc code signature, without which Apple Silicon will not execute the result at all.

**`server.js`** — the browser auto-open is gated behind `AS_NO_OPEN=1`, for headless use and for systems without `xdg-open`. It also moves from `exec` to `execFile`, removing the shell so `PORT` cannot be interpolated into a command line.

**`package.json`** — `engines.node >= 18`.

## Testing, stated precisely

Verified on macOS arm64 by execution:

| Check | Result |
|---|---|
| Launcher from an unrelated working directory | Server started, `GET /` returned 200 |
| Node absent, broken, returning a non-numeric version, or too old | Correct message, exit 1 in each case |
| Path containing spaces, via launcher and Finder shim | Works |
| `AS_NO_OPEN=1` | Server started, no browser opened |
| `node build-exe.js` | Produced a `node18-macos-arm64` binary |
| `codesign -dv` | `Mach-O thin (arm64)`, `flags=0x2(adhoc)` |
| Built binary served the app | `GET /` and `GET /app.js` both 200 |
| Archive round-trip | Executable bit preserved on binary and launcher |
| BSD refusal path in `build-exe.js` | Exercised by overriding `process.platform` |

`bin/start`, the Finder shim, and the generated launcher are all clean under `shellcheck --shell=sh --severity=style`. This matters more than running them locally, because macOS `/bin/sh` is bash in POSIX mode and is more permissive than the `ash` or `pdksh` these scripts meet on the BSDs.

## Footnotes and known limits

**macOS was tested, but without a funded API key.** A valid OpenAI key was entered and the request reached OpenAI, which returned `You have no credits remaining`. That exercises the full proxy chain, browser to local server to provider and back, with the upstream error surfaced correctly in the UI. Image generation itself was not performed, and the Gemini path was not exercised at all.

**Windows is believed unaffected, and the reasoning is stronger than a guess.** On x64 Windows every value this code selects is identical to what was previously hardcoded, so those paths are unchanged by construction.

The one genuinely new case is `node18-win-arm64`, which the original could not request because it hardcoded `x64`. That target has since been verified to exist: `pkg@5.8.1` fetches its base binary and emits a 29.9 MB executable. So an ARM Windows machine now gets a native binary where it previously got an x64 one running under emulation, which is an improvement rather than a regression. The build was performed cross-platform, so the target and the build are proven and the resulting binary running on Windows is not.

Nothing in this PR has been executed on Windows.

**Linux and the BSDs nominally work but have not been tested on them.** No machine was available. The shellcheck pass above is the evidence, and it is evidence rather than execution.

On the BSD refusal specifically: `pkg` recognises a `freebsd` target name, but no base binary is published for it and it declines to cross-build one. Verified against `pkg@5.8.1`, where the fetch returns 404 and the source build is refused off-host. `npm start` is the supported path there and needs nothing from this PR.

**This conflicts with both open PRs, verified by test merge:**

| Against | Conflicts in |
|---|---|
| #1, Grok integration | `server.js`, `README.md` |
| #2, test suite | `server.js` |

Both collide in the `app.listen` block, since #2 rewrites it and #1 rewrites most of the file. `package.json` auto-merges cleanly in both cases. This branch is based on `main` at `bd55eb2` with no drift, so merge ordering is a free choice rather than a constraint.

**`pkg` is archived upstream**, which is why the targets stop at Node 18. Node's own single executable applications feature is the eventual replacement and will need the same macOS signing step. The target and flag handling here is the part that gets rewritten at that point; the launcher work is not throwaway.

**The macOS binary is ad-hoc signed, not notarized.** It runs on the machine that built it. Distributing it to another Mac needs an Apple Developer ID and notarization, or the recipient clearing the quarantine attribute by hand. That is a recurring cost and a separate decision, so it is out of scope here.

**`engines` is advisory.** npm warns rather than fails unless `engine-strict` is set, so it cannot break an existing Node 16 user's install.

**`AS_NO_OPEN` is new and opt-in.** Default behaviour is unchanged.

**`Setup.bat` has no Unix counterpart** by design. The launcher reports what to install instead, which is the correct behaviour on Unix and made a second setup script unnecessary.

## AI assistance

This branch was written with Claude Code. Every commit carries a `Co-Authored-By` trailer. The testing table above reflects commands that were actually run, and the untested platforms are named as such rather than implied to be covered.
